### PR TITLE
add 2+ tag_id filter support

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -14,7 +14,11 @@ class Need < ActiveRecord::Base
 
   default_scope ->{ order('id desc') }
   scope :with_tag_id, -> (tag_id) {
-    joins(:taggings).where("taggings.tag_id" => tag_id)
+    if tag_id.is_a? String
+      joins(:taggings).where("taggings.tag_id in (?)", tag_id.split(',').map(&:to_i))
+    else
+      joins(:taggings).where("taggings.tag_id in (?)", tag_id)
+    end
   }
 
   validates :role, :goal, :benefit, presence: true

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -191,4 +191,25 @@ RSpec.describe Need, type: :model do
     end
   end
 
+  describe '.with_tag_id multiple' do
+    let(:tag) { create(:tag) }
+    let(:tag2) { create(:tag) }
+
+    it 'returns needs tagged with the given tag IDs' do
+      other_needs = create_list(:need, 5)
+
+      expected_need = create(:need)
+      tagging = create(:tagging, tag: tag, need: expected_need)
+
+      expected_need2 = create(:need)
+      tagging2 = create(:tagging, tag: tag2, need: expected_need2)
+
+      # simulate comma-delimited query, e.g. maslow.local/needs?tag_id=1,2
+      results = Need.with_tag_id("#{tag.id},#{tag2.id}")
+      expect(results).to include(expected_need)
+      expect(results).to include(expected_need2)
+      expect(results).to_not include(other_needs)
+    end
+  end
+
 end


### PR DESCRIPTION
To be able to filter on multiple tags, e.g. http://maslow/needs?tag_id=1,2
